### PR TITLE
Add qnote to Notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ That One Privacy Site | https://thatoneprivacysite.net/ | Not a VPN, but a VPN c
 ### Notes (A - Z)
 What | Where | Why | Year Added
 --- | --- | --- | ---
+qnote | https://github.com/Omibranch/qnote | Minimal open-source desktop notepad. Local-only storage with no cloud sync, no account, no telemetry. Markdown live preview, version history, OCR. Available on AUR. | 2026
 Standard Notes | https://standardnotes.com/ | Standard Notes protects your notes and files with 4x-audited industry-leading end-to-end encryption, meaning only you have access to the keys required to decrypt your information. | 2023
 
 ### Networking (A - Z)


### PR DESCRIPTION
## What

Adds [qnote](https://github.com/Omibranch/qnote) to the **Notes (A - Z)** section, alphabetically before Standard Notes.

## Why it fits

qnote is a privacy-respecting desktop notepad:

- **Local-only storage** — no cloud sync, no account required, no network activity
- **No telemetry** — zero data collection of any kind
- Open source (MIT license), code fully auditable
- Features: Markdown with live preview, automatic local version history, OCR via Tesseract
- Available on AUR for Arch Linux users; also works on Windows and macOS

It respects user privacy by design — not through encryption policy, but by never leaving the local machine.